### PR TITLE
Align test package with application

### DIFF
--- a/src/main/java/com/helpunker/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/helpunker/common/handler/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.helpunker.common.handler;
 import com.helpunker.common.exception.BusinessRuleException;
 import com.helpunker.common.exception.ResourceNotFoundException;
 import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.validation.FieldError;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ProblemDetail handleNotFound(ResourceNotFoundException ex) {
@@ -54,6 +58,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleGeneric(Exception ex) {
+        log.error("Unhandled exception caught by GlobalExceptionHandler", ex);
         ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         problem.setTitle("Internal server error");
         problem.setDetail("Unexpected error occurred");

--- a/src/test/java/com/helpunker/HelpUnkerApplicationTests.java
+++ b/src/test/java/com/helpunker/HelpUnkerApplicationTests.java
@@ -1,13 +1,12 @@
-package com.UnkerService;
+package com.helpunker;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class UnkerServiceApplicationTests {
+class HelpUnkerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }


### PR DESCRIPTION
## Summary
- move the context-loads test into the `com.helpunker` package
- rename the Spring Boot context test class to match the application name

## Testing
- `./mvnw test` *(fails: Maven wrapper could not download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db3a05fc10832b94e2e98865b99231